### PR TITLE
Fix errors due to `ActiveModel::Validations.include` being private

### DIFF
--- a/lib/carrierwave/virus_free.rb
+++ b/lib/carrierwave/virus_free.rb
@@ -10,4 +10,4 @@ module CarrierWave
   end
 end
 
-ActiveModel::Validations.include CarrierWave::VirusFree
+ActiveModel::Validations.send :include, CarrierWave::VirusFree


### PR DESCRIPTION
I'm currently getting the following error when I try to start my rails app with this gem installed:

```ruby
/home/rob/.rvm/gems/ruby-2.0.0-p648/gems/carrierwave-virus_free-0.1.0/lib/carrierwave/virus_free.rb:13:in `<top (required)>': private method `include' called for ActiveModel::Validations:Module (NoMethodError)
```

This pull request fixes that issue.